### PR TITLE
Ability to create new teams on Github #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# custom configurations
+config.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# EclipseFdn GitHub Sync toolset
+
+## Running the toolset
+
+1. Clone the repository
+2. Create a `config.py` in the src folder, using the config.sample.py file as a template. Update the git_src token variable with a valid access token.
+3. Run `python src/Sync.py -h` to discover usages for the toolset.
+
+## Maintainers
+
+**Martin Lowe (Eclipse Foundation)**
+
+- <https://github.com/autumnfound>
+
+## Trademarks
+
+* Eclipse® is a Trademark of the Eclipse Foundation, Inc.
+* Eclipse Foundation is a Trademark of the Eclipse Foundation, Inc.
+
+## Copyright and license
+
+Copyright 2019 the [Eclipse Foundation, Inc.](https://www.eclipse.org) and the [eclipsefdn-github-sync authors](https://github.com/eclipsefdn/eclipsefdn-github-sync/graphs/contributors). Code released under the [Eclipse Public License Version 2.0 (EPL-2.0)](https://github.com/eclipsefdn/eclipsefdn-github-sync/blob/master/LICENSE).

--- a/src/Sync.py
+++ b/src/Sync.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+import config as cfg
+from SyncClient import SyncClient
+from github.GithubException import UnknownObjectException, GithubException
+
+import re, sys, argparse
+
+def __run():
+    src = SyncClient.get_github_client(cfg.git_src)
+    if args.create_team:
+        __create_team(src,args.create_team[0],args.create_team[1])
+    else:
+        for org in src.get_user().get_orgs():
+            # TODO: do we want to fallback or just use .login?
+            org_display = org.name or org.login
+            ## check that we match the org for one of our filters
+            if __org_matches(org_display):
+                for repo in org.get_repos():
+                    print("Working with " + org_display + ":" + repo.name)
+                    __process_issues(repo.get_issues())
+            else:
+                print(org_display + " doesn\'t match given organization filters, skipping")
+
+
+
+# Creates a team with team_name, in the organization with login name of target_org,
+# using the access rights of the current github_client
+def __create_team(github_client, target_org, team_name):
+    try:
+        # try to retrieve organization with given login name
+        org = github_client.get_organization(target_org)
+        # in case we somehow don't get a valid org, return
+        if not org:
+            print(target_org+' doesn\'t match an available organization login string')
+            return;
+
+        # Indicate the found result, and create the team (if not dry run)
+        print('Target org of '+target_org+' found! Creating team with name '+team_name)
+        if not args.dry_run:
+            org.create_team(team_name, privacy='closed')
+    except UnknownObjectException:
+        # exception thrown when there is no org with matching login
+        print('ERROR: ' + target_org + ' doesn\'t match an available organization login string')
+    except GithubException:
+        # exception thrown when there is a team that exists with the given name
+        print('ERROR: ' + team_name + ' already exists as a team within the given organization')
+
+
+# The 'Do stuff' method for issues. This will have more stuff in it later.
+def __process_issues(issues):
+    for issue in issues:
+        print('\t' + issue.title + ' #' + str(issue.number))
+
+
+# Check that the org name matches the patterns/names set in the method arguments, which
+# is by default the set of configuration organizations.
+def __org_matches(org_name, org_patterns=cfg.orgs):
+    for org_pattern in org_patterns:
+        re_match = re.search(org_pattern, org_name)
+        if re_match and re_match.group:
+            return True
+    return None
+
+
+# Convert lists or singular var into a list of exclusive patterns for use in regex.
+# While the strings can be used straight, this ensures there's no accidental partial matches.
+def __generate_patterns_for_orgs(orgs):
+    patterns = []
+    if isinstance(orgs, list):
+        for org in orgs:
+            # wrap org name in ^<string>$ to make exclusive instead of inclusive search
+            patterns.append('^'+org+'$')
+    elif isinstance(orgs, str):
+        patterns.append('^'+orgs+'$')
+    return patterns
+
+
+# get the CLI arguments
+parser = argparse.ArgumentParser(description='TODO.')
+parser.add_argument('-C', '--create_team', nargs=2, metavar="str", help="Creates a team with the following 2 arguments, the first being the target organization and the second being the new team name")
+parser.add_argument('-d', '--dry_run', action="store_true", help="Enables dry run for the script, disabling writing functionality")
+args = parser.parse_args(sys.argv[1:])
+
+## Go back to top and run the script
+__run()

--- a/src/SyncClient.py
+++ b/src/SyncClient.py
@@ -1,0 +1,33 @@
+from github import Github
+
+class SyncClient:
+
+    @staticmethod
+    def get_hosted_client(cfg):
+        # if the onject passed is falsy, return
+        if not cfg:
+            return None
+        # check that the host is set
+        if not cfg["host"]:
+            print("ERROR: no host provided for Github client")
+            return None
+        # check that the token is set
+        if not cfg["token"]:
+            print("ERROR: no token provided for Github client")
+            return None
+
+        # return a fresh client with the given host + token for access
+        return Github(base_url = cfg["host"], login_or_token = cfg["token"])
+
+    @staticmethod
+    def get_github_client(cfg):
+        # if the onject passed is falsy, return
+        if not cfg:
+            return None
+        # check that the token is set
+        if not cfg["token"]:
+            print("ERROR: no token provided for Github client")
+            return None
+
+        # return a fresh client using github.com with the token for access
+        return Github(cfg["token"])

--- a/src/config.sample.py
+++ b/src/config.sample.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+orgs = ['Eclipse Test']
+git_src = {"type": "github",
+           "token": " 123abc456def789ghi123abc456def789ghi"}


### PR DESCRIPTION
Added base code for retrieving GitHub client from PyGithub, updated gitignore to not include actual config file, and code to create a new team for an organization. Created basic README file.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>