### PR TITLE
Fix log dates and dryrun is now the default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,10 @@ services:
       - ./.cache:/app/.cache
     environment:
       - VERBOSE_VAL=true
+      - DRYRUN=true
     secrets:
       - api-token
-      
+
 secrets:
   api-token:
     file: secret
-            

--- a/k8s/cronjob.yml
+++ b/k8s/cronjob.yml
@@ -18,7 +18,7 @@ spec:
             args:
             - /bin/sh
             - -c
-            - npm start -- --verbose=true --dryrun=true | tee -a /app/logs/stdout-$(date +%Y%m%d).log
+            - npm start -- --verbose=true --dryrun=true | tee -a /app/logs/stdout-$(date +%Y-%m-%d).log
             volumeMounts:
             - name: logs
               mountPath: /app/logs

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/eclipsefdn/eclipsefdn-github-sync.git"
   },
   "author": "Martin Lowe",
-  "scripts" : {
+  "scripts": {
     "start": "node src/Sync.js"
   },
   "license": "EPL-2.0",

--- a/src/Client.js
+++ b/src/Client.js
@@ -16,7 +16,7 @@ const fs = require('fs');
 const winston = require('winston');
 
 var now = new Date();
-winston.add(new winston.transports.File({ filename: `logs/cli-${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDay()}.log` }));
+winston.add(new winston.transports.File({ filename: `logs/cli-${now.getUTCFullYear()}-${now.getUTCMonth()+1}-${now.getUTCDate()}.log` }));
 winston.add(new winston.transports.Console({ level: 'error' }));
 
 // set up yargs command line parsing

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -50,7 +50,7 @@ winston.configure({
     ),
   transports: [
     new winston.transports.File({ 
-      filename: `logs/sync-${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDay()}.log`, 
+      filename: `logs/sync-${now.getUTCFullYear()}-${now.getUTCMonth()+1}-${now.getUTCDate()}.log`, 
       level: 'debug' 
       }),
     new winston.transports.Console({ level: argv.V ? 'debug' : 'error' })


### PR DESCRIPTION
The getUTCDay() method returns the day of the week (from 0 to 6) for the
specified date, according to universal time. We should use getUTCDate
since it returns the day of the month (from 1 to 31) of the date object,
according to universal time.

Signed-off-by: Christopher Guindon <chris.guindon@eclipse-foundation.org>