### PR TITLE
Added first phase of Github user eviction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG VERBOSE_VAL=false
 ENV VERBOSE_VAL ${VERBOSE_VAL:-false}
 ARG DRYRUN=false
 ENV DRYRUN ${DRYRUN:-false}
+ARG DRYRUN_DELETION=false
+ENV DRYRUN_DELETION ${DRYRUN_DELETION:-false}
 
 ## Copy NPM configs and install dependencies
 COPY package*.json ./
@@ -13,4 +15,4 @@ RUN npm install
 COPY ./src/* ./src/
 
 ## run the script
-CMD npm start -- --verbose=$VERBOSE_VAL --dryrun=$DRYRUN
+CMD npm start -- --verbose=$VERBOSE_VAL --dryrun=$DRYRUN --deletionDryRun=$DRYRUN_DELETION


### PR DESCRIPTION
First phase consists of checking Eclipse API and if we have a response
and can verify its the same user, they are then removed from the team.
Added new -D flag to run in semi dry mode, where only deletion is
limited.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>