### PR TITLE
Fix for failed tests in EclipseAPI test file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "10"
   - "12"
 install:
 - npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12
 WORKDIR /app
 ARG VERBOSE_VAL=false
 ENV VERBOSE_VAL ${VERBOSE_VAL:-false}

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -10,7 +10,7 @@
 # docker run -i --rm -v <full path to a file folder>:/run/secrets eclipsefdn/gitlab-sync
 #
 ###
-FROM node:10
+FROM node:12
 WORKDIR /app
 ARG VERBOSE_VAL=false
 ENV VERBOSE_VAL ${VERBOSE_VAL:-false}

--- a/src/EclipseAPI.js
+++ b/src/EclipseAPI.js
@@ -6,7 +6,7 @@ module.exports = class EclipseAPI {
     #config;
     #client;
     #accessToken;
-    constructor(config) {
+    constructor(config = {}) {
         this.#config = config;
         // if we have oauth config, intialize access token
         if (this.#config.oauth !== undefined) {


### PR DESCRIPTION
Added default value for conig constructor arg of empty object. This
allows empty param constructors to build an unauthorized wrapper object.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>