### PR TITLE
Fix to allow GH sync logs to capture ERR OUT logs as well as STD

### DIFF
--- a/k8s/cronjob.yml
+++ b/k8s/cronjob.yml
@@ -28,7 +28,7 @@ spec:
             args:
             - /bin/sh
             - -c
-            - npm start -- --verbose=true | tee -a /app/logs/stdout-$(date +%Y-%m-%d).log
+            - npm start -- --verbose=true 2>&1 | tee -a /app/logs/stdout-$(date +%Y-%m-%d).log
             volumeMounts:
             - name: logs
               mountPath: /app/logs


### PR DESCRIPTION
Fix based on code in the GL script which was updated in collaboration
with release folks.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>