### PR TITLE
Fix brittle test that causes build timeouts #95

### DIFF
--- a/src/EclipseAPI.js
+++ b/src/EclipseAPI.js
@@ -25,14 +25,14 @@ module.exports = class EclipseAPI {
     }
   }
 
-  async eclipseAPI() {
+  async eclipseAPI(paginate = true) {
     var hasMore = true;
     var result = [];
     var data = [];
     // add timestamp to url to avoid browser caching
     var url = 'https://projects.eclipse.org/api/projects';
     // loop through all available users, and add them to a list to be returned
-    while (hasMore) {
+    while (hasMore && paginate) {
       console.log('Loading next page...');
       // get the current page of results, incrementing page count after call
       result = await axios.get(url).then(r => {

--- a/test/EclipseAPITest.js
+++ b/test/EclipseAPITest.js
@@ -10,8 +10,8 @@ describe('EclipseAPI', function() {
 		describe('success', function() {
 			var result;
 			before(async function() {
-				// get eclipse projects
-				result = await EclipseAPI.eclipseAPI();
+				// get eclipse projects, disable pagination as this is a long process
+				result = await EclipseAPI.eclipseAPI(false);
 			});
 
 			it('should contain JSON data', function() {
@@ -22,11 +22,16 @@ describe('EclipseAPI', function() {
 					expect(result[0]).to.have.property('project_id').that.is.a('string');
 				}
 			});
-			it('should contain github_repos field', function() {
-				if (result.length > 0) {
-					expect(result[0]).to.have.property('github_repos').that.is.an('array');
-				}
-			});
+      it('should contain github_repos field', function() {
+        if (result.length > 0) {
+          expect(result[0]).to.have.property('github_repos').that.is.an('array');
+        }
+      });
+      it('should contain gitlab_repos field', function() {
+        if (result.length > 0) {
+          expect(result[0]).to.have.property('gitlab_repos').that.is.an('array');
+        }
+      });
 		});
 	});
 	
@@ -149,7 +154,7 @@ describe('EclipseAPI', function() {
 				}
 				
 				// get bots with filtered list
-				result = await EclipseAPI.processBots(bots, siteName);
+				result = EclipseAPI.processBots(bots, siteName);
 			});
 
 			it('should contain object data', function() {


### PR DESCRIPTION
Add option to bypass pagination for EclipseAPI. While this isn't useful
for production, this allows for safer testing. Update EclipseAPI tests
to use new pagination param to byass pagination when testing.

Include test for gitlab repos that was previously missed.

Fixes #95

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>