### PR TITLE
Do not reset contributor team's permissions if it's set to "triage" #50

### DIFF
--- a/src/Sync.js
+++ b/src/Sync.js
@@ -203,7 +203,7 @@ async function processRepositories(repos, project) {
 
         // Ensure that the teams refer to the repo
         await wrap.addRepoToTeam(org, `${project.project_id}-committers`, repoName, 'push');
-        await wrap.addRepoToTeam(org, `${project.project_id}-contributors`, repoName);
+        await wrap.addRepoToTeam(org, `${project.project_id}-contributors`, repoName, 'triage');
         await wrap.addRepoToTeam(org, `${project.project_id}-project-leads`, repoName, 'pull', false);
       } catch (e) {
         console.log(`Error while updating ${project.project_id}. \n${e}`);


### PR DESCRIPTION
Use no overwrite option for adding repo to team access permissions, with
default permissions of pull.

Fixes #50

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>