### PR TITLE
use --no-cache when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ ENV DRYRUN ${DRYRUN:-false}
 ARG DRYRUN_DELETION=false
 ENV DRYRUN_DELETION ${DRYRUN_DELETION:-false}
 
+## Copy over required script files
+COPY src src/
+
 ## Copy NPM configs and install dependencies
 COPY package*.json ./
-RUN npm install
-
-## Copy over required script files
-COPY ./src/ ./src/
+RUN npm ci
 
 ## run the script
 CMD npm start -- --verbose=$VERBOSE_VAL --dryrun=$DRYRUN --deletionDryRun=$DRYRUN_DELETION --tls-min-v1.0

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -21,12 +21,12 @@ ENV PROVIDER ${PROVIDER:-oauth2_generic}
 ARG HOST=https://gitlab-test.eclipse.org
 ENV HOST ${HOST:-https://gitlab-test.eclipse.org}
 
+## Copy over required script files
+COPY src src/
+
 ## Copy NPM configs and install dependencies
 COPY package*.json ./
-RUN npm install
-
-## Copy over required script files
-COPY ./src/* ./src/
+RUN npm ci
 
 ## run the script
 CMD npm run lab-sync -- --verbose=$VERBOSE_VAL --dryrun=$DRYRUN --provider=$PROVIDER --host=$HOST --tls-min-v1.0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,8 @@ pipeline {
       }
       steps {
         sh '''
-          docker build --no-cache --pull -t ${IMAGE_NAME}:${TAG_NAME} -t ${IMAGE_NAME}:latest .
-          docker build --no-cache --pull -t ${GL_IMAGE_NAME}:${TAG_NAME} -t ${GL_IMAGE_NAME}:latest -f Dockerfile.gitlab .
+          docker build --pull -t ${IMAGE_NAME}:${TAG_NAME} -t ${IMAGE_NAME}:latest .
+          docker build --pull -t ${GL_IMAGE_NAME}:${TAG_NAME} -t ${GL_IMAGE_NAME}:latest -f Dockerfile.gitlab .
         '''
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,8 @@ pipeline {
       }
       steps {
         sh '''
-          docker build --pull -t ${IMAGE_NAME}:${TAG_NAME} -t ${IMAGE_NAME}:latest .
-          docker build --pull -t ${GL_IMAGE_NAME}:${TAG_NAME} -t ${GL_IMAGE_NAME}:latest -f Dockerfile.gitlab .
+          docker build --no-cache --pull -t ${IMAGE_NAME}:${TAG_NAME} -t ${IMAGE_NAME}:latest .
+          docker build --no-cache --pull -t ${GL_IMAGE_NAME}:${TAG_NAME} -t ${GL_IMAGE_NAME}:latest -f Dockerfile.gitlab .
         '''
       }
     }


### PR DESCRIPTION
Jenkins seems to be deploying a cached version of the sync script.

Signed-off-by: Christopher Guindon <chris.guindon@eclipse-foundation.org>