### PR TITLE
Fix processBots call to have the site endpoint

### DIFF
--- a/src/GitlabSync.js
+++ b/src/GitlabSync.js
@@ -100,8 +100,8 @@ async function run(secret, eclipseToken) {
   data = eApi.postprocessEclipseData(data, 'gitlab_repos');
 
   // get the bots for the projects
-  var rawBots = await eApi.eclipseBots('gitlab.eclipse.org');
-  bots = eApi.processBots(rawBots);
+  var rawBots = await eApi.eclipseBots();
+  bots = eApi.processBots(rawBots, 'gitlab.eclipse.org');
 
   // get all current groups for the instance
   var groups = await api.Groups.all();


### PR DESCRIPTION
Move site endpoint of gitlab.eclipse.org that was passed to the
EclipseBots call to the processBots (where it is needed).

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>