### PR TITLE
Fix linting error in regex for useless escape character

### DIFF
--- a/src/GitlabSync.js
+++ b/src/GitlabSync.js
@@ -527,7 +527,7 @@ function sanitizeGroupName(pid) {
     console.log(`GitlabSync:sanitizeGroupName(pid = ${pid})`);
   }
   if (pid !== undefined) {
-    return pid.toLowerCase().replace(/[^\s\da-zA-Z-\.]/g, '-');
+    return pid.toLowerCase().replace(/[^\s\da-zA-Z-.]/g, '-');
   }
   return '';
 }


### PR DESCRIPTION
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>