### PR TITLE
Add check and cleanup operation on project permisions

### DIFF
--- a/src/GitlabSync.js
+++ b/src/GitlabSync.js
@@ -133,7 +133,7 @@ async function run(secret, eclipseToken) {
     if (argv.d) {
       logger.error('Unable to start sync of GitLab content. Base Eclipse group could not be found and dryrun is set');
     } else {
-      logger.errpr('Unable to start sync of GitLab content. Base Eclipse group could not be created');
+      logger.error('Unable to start sync of GitLab content. Base Eclipse group could not be created');
     }
     return;
   }
@@ -141,7 +141,7 @@ async function run(secret, eclipseToken) {
   for (projectIdx in data) {
     var project = data[projectIdx];
     if (argv.P !== undefined && project.short_project_id !== argv.P) {
-      console.log(`Project target set ('${argv.P}'). Skipping non-matching project ID ${project.short_project_id}`);
+      logger.info(`Project target set ('${argv.P}'). Skipping non-matching project ID ${project.short_project_id}`);
       continue;
     }
     logger.info(`Processing '${project.short_project_id}'`);
@@ -246,7 +246,7 @@ async function cleanUpProjectUsers(project, projectID) {
       logger.debug(`Dryrun flag active, would have removed user '${member.username}' from project '${project.name}'(${project.id})`);
       continue;
     }
-    console.log(`Removing user '${member.username}' from project '${project.name}'(${project.id})`);
+    logger.info(`Removing user '${member.username}' from project '${project.name}'(${project.id})`);
     try {
       await api.ProjectMembers.remove(project.id, member.id);
     } catch (err) {
@@ -441,7 +441,7 @@ async function getUser(uname, url) {
   var u = namedUsers[uname];
   if (u === undefined) {
     if (argv.d) {
-      console.log(`Dryrun is enabled. Would have created user ${uname} but was skipped`);
+      logger.info(`Dryrun is enabled. Would have created user ${uname} but was skipped`);
       return;
     }
 

--- a/src/HttpWrapper.js
+++ b/src/HttpWrapper.js
@@ -67,7 +67,9 @@ class HttpWrapper {
         this.#httpCache.setKey(url, result.data);
         return result.data;
       })
-      .catch(err => this.#logger.error(err));
+      .catch(err => {
+        this.#logger.error(err);
+      });
   }
 
   async getRaw(url) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -26,9 +26,9 @@ module.exports.getLogger = function(level, name = 'main') {
     level: level,
     format: format.combine(
       format.timestamp({
-        format: 'YYYY-MM-DDTHH:mm:ss'
+        format: 'YYYY-MM-DDTHH:mm:ss',
       }),
-      format.printf((info) => {
+      format.printf(info => {
         return `${info.timestamp} [${name}] ${info.level.toUpperCase()} ${info.message}`;
       })),
     transports: [

--- a/src/teams/StaticTeamManager.js
+++ b/src/teams/StaticTeamManager.js
@@ -166,7 +166,11 @@ class StaticTeamManager {
   }
 
   getPermissionsForTeam(team, serviceType) {
-    if (team === null || serviceType === null) {
+    if (team === null) {
+      this.#logger.warn('Cannot get permissions for null team');
+      return null;
+    }
+    if (serviceType === null) {
       this.#logger.warn(`Cannot get permissions for team ${team.teamName} with no service type`);
       return null;
     }

--- a/test/HttpWrapperTest.js
+++ b/test/HttpWrapperTest.js
@@ -68,7 +68,7 @@ describe('HttpWrapper', function() {
 				result = await http.getData("https://api.eclipse.org/account/profile/webmaster-123456789456123");
 			});
 
-			it('should return undefiend as response for error', function() {
+			it('should return undefined as response for error', function() {
 				expect(result).to.be.undefined;
 			});
 		});


### PR DESCRIPTION
Only removes users that are directly set on projects that are not bots
or not admins.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>