### PR TITLE
Add parameter to sync runs to allow for targeting of a single ...#150

### DIFF
--- a/src/GitlabSync.js
+++ b/src/GitlabSync.js
@@ -27,6 +27,10 @@ var argv = require('yargs')
     description: 'The OAuth provider name set in GitLab',
     default: 'oauth2_generic',
   })
+  .option('P', {
+    alias: 'project',
+    description: 'The short project ID of the target for the current sync run',
+  })
   .option('s', {
     alias: 'secretLocation',
     description: 'The location of the access-token file containing an API access token',
@@ -133,6 +137,10 @@ async function run(secret, eclipseToken) {
 
   for (projectIdx in data) {
     var project = data[projectIdx];
+    if (argv.P !== undefined && project.short_project_id !== argv.P) {
+      console.log(`Project target set ('${argv.P}'). Skipping non-matching project ID ${project.short_project_id}`);
+      continue;
+    }
     console.log(`Processing '${project.short_project_id}'`);
     // fetch project group from results, create if missing
     var projGroup = await getGroup(project.name, project.short_project_id, g);

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -40,6 +40,10 @@ var argv = require('yargs')
     description: 'Runs the script in a semi-dryrun state to prevent deletions of users',
     boolean: true,
   })
+  .option('p', {
+    alias: 'project',
+    description: 'The project ID that should be targeted for this sync run',
+  })
   .option('s', {
     alias: 'secretLocation',
     description: 'The location of the access-token file containing an API access token',
@@ -141,6 +145,10 @@ async function runSync(data) {
     var project = data[key];
     var projectID = project.project_id;
     var repos = project.github_repos;
+    if (argv.p !== undefined && projectID !== argv.p) {
+      console.log(`Project target set ('${argv.p}'). Skipping non-matching project ${projectID}`);
+      continue;
+    }
     console.log(`Project ID: ${projectID}`);
 
     // maintain orgs used by this project


### PR DESCRIPTION
Add project ID target as param in sync scripts.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>