### PR TITLE
Update Jenkins build to deploy for production branch rather than master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
 
     stage('Push docker image') {
       when {
-        branch 'master'
+        branch 'production'
       }
       agent {
         label 'docker-build'
@@ -79,7 +79,7 @@ pipeline {
 
     stage('Deploy to cluster') {
       when {
-        branch 'master'
+        branch 'production'
       }
       steps {
         container('kubectl') {


### PR DESCRIPTION
Fixes #154

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>