### PR TITLE
Investigate if all GitHub teams can be made public #128

### DIFF
--- a/src/Sync.js
+++ b/src/Sync.js
@@ -318,7 +318,7 @@ async function updateTeam(org, teamName, designatedMembers) {
   console.log(`Syncing team '${teamName}' for organization ${org}`);
   var team = await wrap.addTeam(org, teamName);
   // set team to private
-  await wrap.editTeam(org, teamName, { privacy: 'secret' });
+  await wrap.editTeam(org, teamName, { privacy: 'closed' });
   var members = await wrap.getTeamMembers(org, team);
 
   console.log(`${teamName} members: ${JSON.stringify(designatedMembers)}`);


### PR DESCRIPTION
Fixes #128

Update to set all teams to 'closed' rather than 'secret'

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>