### PR TITLE
Add CLI parameter tables to the README for sync scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,34 @@ docker build -f Dockerfile -t ef/gh-test .
 docker run -i --rm -v <fullpath to current project folder>/secrets:/run/secrets --env DRYRUN=true ef/gh-test
 ```
 
+## Manual run parameters
+
+The following parameters can be used when running the sync scripts manually.
+
+### Github
+
+| Parameter name | Required | Accepts | Default | Description |
+|----------------|:--------:|---------|---------|-------------|
+|-s, --secretLocation | ✓ | string | N/A | The location of the files containing API access tokens and secure configurations containing keys. |
+|-d, --dryRun | x | boolean flag | `false` | Runs script in dry run mode, not writing any changes to the API. |
+|-D, --deletionDryRun | x | boolean flag | `false` | Runs script in deletion dry run mode, not performing any deletion operations to the API. |
+|-t, --devMode | x | boolean flag | `false` | Runs the script with the dev mode active. This changes the returned data from the Eclipse API to affect a dev sandbox rather than production projects. |
+|-h, --help | x | N/A (flag) | N/A | Prints the help text for the script parameters. |
+|-V, --verbose | x | boolean flag | `false` | Sets the script to run in verbose mode (ranges from 1-4 for more verbose logging). |
+
+### Gitlab
+
+| Parameter name | Required | Accepts | Default | Description |
+|----------------|:--------:|---------|---------|-------------|
+|-s, --secretLocation | ✓ | string | N/A | The location of the files containing API access tokens and secure configurations containing keys. |
+|-d, --dryRun | x | boolean flag | `false` | Runs script as dry run, not writing any changes to API. |
+|-D, --devMode | x | boolean flag | `false` | Runs the script with the dev mode active. This changes the returned data from the Eclipse API to affect a dev sandbox rather than production projects. |
+|-H, --host | x | string | `https://gitlab.eclipse.org` | The Gitlab host target for the sync. This allows for testing and staging migrations for use in development and dry runs. |
+|-h, --help | x | N/A (flag) | N/A | Prints the help text for the script parameters. |
+|-p, --provider | x | string | `oauth2_generic` | The OAuth provider name set in GitLab for the Eclipse Accounts binding. |
+|-V, --verbose | x | boolean flag | `false` | Sets the script to run in verbose mode (ranges from 1-4 for more verbose logging). |
+
+
 ## Maintainers
 
 **Martin Lowe (Eclipse Foundation)**


### PR DESCRIPTION
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>